### PR TITLE
fix: Fix pp is undefined error

### DIFF
--- a/scripts/get_comic_home.py
+++ b/scripts/get_comic_home.py
@@ -23,7 +23,7 @@ def searchComic(pattern):
         title = row.find('span').getText()
     
         if title == pattern:
-            return 'https://comicbus.com' + row.find('a', href=True)['href']
+            return row.find('a', href=True)['href']
 
     raise None
 

--- a/scripts/nodejs_get_images/get_images.js
+++ b/scripts/nodejs_get_images/get_images.js
@@ -20,8 +20,7 @@ const spp = () => {}`
 const episode_url = process.argv?.[2] || null
 const isVerbose = false
 
-async function Request(url)
-{
+async function Request(url) {
     return fetch(url, {
         headers: {
             "Cookie": "RI=0"
@@ -29,13 +28,11 @@ async function Request(url)
     })
 }
 
-function FirstOrDefault (args) 
-{
+function FirstOrDefault(args) {
     return args?.[0]
 }
 
-async function FetchImageAmount(url, evalScriptPrefix)
-{
+async function FetchImageAmount(url, evalScriptPrefix) {
     if (isVerbose)
         console.error(`[FetchImageAmount] [${url}] Fetching url`)
 
@@ -59,17 +56,16 @@ async function FetchImageAmount(url, evalScriptPrefix)
     const IncludeSrc = el => el.includes('src=')
     const srcScript = FirstOrDefault(script.split(';').filter(IncludeSrc))?.replace(/.*\.src=/, '')
     if (isVerbose)
-       console.error(`[FetchImageSrc] [${url}] srcScript = [${srcScript}]`)
+        console.error(`[FetchImageSrc] [${url}] srcScript = [${srcScript}]`)
 
-    const evalScript = [evalScriptPrefix, script, srcScript, '(ps)'].join(';')
+    const evalScript = [evalScriptPrefix, script, '(ps)'].join(';')
     if (isVerbose)
         console.error(`[FetchImageSrc] [${url}] evalScript = [${evalScript}]`)
 
     return eval(evalScript)
 }
 
-async function FetchImageSrc(url, evalScriptPrefix)
-{
+async function FetchImageSrc(url, evalScriptPrefix) {
     if (isVerbose)
         console.error(`[FetchImageSrc] [${url}] Fetching url`)
 
@@ -92,10 +88,11 @@ async function FetchImageSrc(url, evalScriptPrefix)
     // 
     // we use replace to remove "ge(k0__0r_4av(6)+k0__0r_4av(5)).src=" part
     const IncludeSrc = el => el.includes('src=')
-    const srcScript = FirstOrDefault(script.split(';').filter(IncludeSrc))?.replace(/.*\.src=/, '')
+    let srcScript = FirstOrDefault(script.split(';').filter(IncludeSrc))?.replace(/.*\.src=/, '')
+    srcScript = `(pp => { return ${srcScript} })(p)`
     if (isVerbose)
         console.error(`[FetchImageSrc] [${url}] srcScript = [${srcScript}]`)
-    
+
     const evalScript = [evalScriptPrefix, script, `(${srcScript})`].join(';')
     if (isVerbose)
         console.error(`[FetchImageSrc] [${url}] evalScript = [${evalScript}]`)
@@ -148,7 +145,6 @@ async function Run() {
     const tasks = [...Array(episodeImageCount).keys()]
         .map(x => x + 1)
         .map(i => FetchImageSrc(`${url}-${i}`, evalScriptPrefix))
-    
     const taskResults = await Promise.all(tasks)
 
     return {
@@ -167,7 +163,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     else {
         (async () => {
             const result = await Run()
-            console.log(JSON.stringify(result))
+            console.log(JSON.stringify(result, null, 4))
         })();
     }
 }


### PR DESCRIPTION
對方改實作了, 以往可以直接拿到的 pp 現在從 global variable 改為被包在 shw 這個函式內, 因此改為:

1. 拿 episode 數量不需要知道 pp, 故移除
2. 改用一個匿名函式模仿 shw 並呼叫

Reference: 拿圖片網址的部分

```javascript
for (var i = 0; i < 315; i++) {
    var fldxrf6b = lc(w_w1_cm816(nf1jvlr, i * (p8qb457 + 1) + 0, 2));
    var a6b11_p = lc(w_w1_cm816(nf1jvlr, i * (x7177_b7y6 - 2) + 2, 2));
    var x05_6yex_3 = lc(w_w1_cm816(nf1jvlr, i * (p8qb457 + 1) + 4));
    var ypw19c05_6 = lc(w_w1_cm816(nf1jvlr, i * (cr_2r__w - 1) + 44, 2));
    var bex_38k = lc(w_w1_cm816(nf1jvlr, i * (cr_2r__w - 1) + 46, 2));
    ps = ypw19c05_6;
    if (fldxrf6b == ch) {
        ci = i;

        // 這行改了, 原本的寫法直接 eval (  unescape(bs378_3 ... pos0tly(1)); ) 的寫法
        // 會因為找不到 pp (實際上應該為 p) 而有問題
        function shw(pp) {
            ge(pos0tly(6) + pos0tly(5)).src = unescape(bs378_3 + bs378_3 + pos0tly(4) + w_w1_cm816(a6b11_p, 0, 1) + y34_pvs378 + y31nif3opa + pos0tly(3) + pos0tly(2) + pos0tly(3) + bs378_3 + w_w1_cm816(a6b11_p, 1, 1) + bs378_3 + ti + bs378_3 + fldxrf6b + bs378_3 + nn(pp) + jy6vj8p0a1 + w_w1_cm816(x05_6yex_3, mm(pp), 3) + y34_pvs378 + pos0tly(1));
        }
        shw(p);

        pi = ci > 0 ? lc(w_w1_cm816(nf1jvlr, ci * (cr_2r__w - 1) - (p8qb457 + 1) + 0, 2)) : ch;
        ni = ci < chs - 1 ? lc(w_w1_cm816(nf1jvlr, ci * (p8qb457 + 1) + (x7177_b7y6 - 2) + 0, 2)) : ch;
        break;
    }
};
```